### PR TITLE
Bump up mcp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "boto3>=1.37.11",
-    "mcp[cli]>=1.3.0",
+    "mcp[cli]>=1.6.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary
Bump up mcp version

### Changes

Bump up mcp version to 1.6 based on https://github.com/modelcontextprotocol/quickstart-resources/issues/24#issuecomment-2837291624 

### User experience

resolves: `from mcp.server.fastmcp import FastMCP ModuleNotFoundError: No module named 'mcp'` error, that I was getting when I checked-out the project.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).
