### PR TITLE
feat: add search_logs_multi for querying multiple log groups

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,8 @@ The server provides the following tool handlers for AI assistants:
 | Tool | Description |
 |------|-------------|
 | `list_log_groups` | List available CloudWatch log groups with filtering options |
-| `search_logs` | Execute CloudWatch Logs Insights queries |
+| `search_logs` | Execute CloudWatch Logs Insights queries on a single log group |
+| `search_logs_multi` | Execute CloudWatch Logs Insights queries across multiple log groups |
 | `filter_log_events` | Filter logs by pattern across all streams |
 | `summarize_log_activity` | Generate time-based activity summaries |
 | `find_error_patterns` | Identify common error patterns |

--- a/src/client.py
+++ b/src/client.py
@@ -120,6 +120,20 @@ search_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 
+# Search multiple log groups command
+search_multi_parser = subparsers.add_parser(
+    "search-multi", help="Search for patterns across multiple CloudWatch log groups"
+)
+search_multi_parser.add_argument(
+    "log_group_names", nargs="+", help="List of log group names to search"
+)
+search_multi_parser.add_argument(
+    "query", help="The search query (CloudWatch Logs Insights syntax)"
+)
+search_multi_parser.add_argument(
+    "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
+)
+
 # Summarize log activity command
 summarize_parser = subparsers.add_parser(
     "summarize", help="Generate a summary of log activity"
@@ -302,6 +316,17 @@ async def main():
                         "search_logs",
                         arguments={
                             "log_group_name": args.log_group_name,
+                            "query": args.query,
+                            "hours": args.hours,
+                        },
+                    )
+                    print_json_response(result)
+
+                elif args.command == "search-multi":
+                    result = await session.call_tool(
+                        "search_logs_multi",
+                        arguments={
+                            "log_group_names": args.log_group_names,
                             "query": args.query,
                             "hours": args.hours,
                         },

--- a/src/cw-mcp-server/server.py
+++ b/src/cw-mcp-server/server.py
@@ -233,6 +233,24 @@ async def search_logs(log_group_name: str, query: str, hours: int = 24) -> str:
 
 
 @mcp.tool()
+async def search_logs_multi(
+    log_group_names: List[str], query: str, hours: int = 24
+) -> str:
+    """
+    Search logs across multiple log groups using CloudWatch Logs Insights.
+    
+    Args:
+        log_group_names: List of log groups to search
+        query: CloudWatch Logs Insights query in Logs Insights syntax
+        hours: Number of hours to look back (default: 24)
+    
+    Returns:
+        JSON string with search results
+    """
+    return await search_tools.search_logs_multi(log_group_names, query, hours)
+
+
+@mcp.tool()
 async def filter_log_events(
     log_group_name: str, filter_pattern: str, hours: int = 24
 ) -> str:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5 

## Summary

### Changes

Added support for searching within multiple CloudWatch log groups simultaneously. This enhances the tool's capabilities by enabling users to run a single query across multiple log groups, which is particularly useful for correlating events across different AWS services or components.

Key changes include:
- Added a new `search_logs_multi` method in `search_tools.py` that accepts a list of log groups
- Refactored existing `search_logs` to use this new method
- Added a new tool handler in the MCP server for multi-log group search
- Added a new CLI command `search-multi` to invoke this functionality
- Updated documentation to reflect the new capability

### User experience

**Before:**
Users needed to execute separate search queries for each log group they wanted to analyze.

**After:**
Users can now search across multiple log groups in a single command/request. Results include the source log group information, making it easier to correlate related events across different services.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).
