### PR TITLE
feat: add start and end time parameters to log search functions

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -119,6 +119,12 @@ search_parser.add_argument(
 search_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
+search_parser.add_argument(
+    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+)
+search_parser.add_argument(
+    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+)
 
 # Search multiple log groups command
 search_multi_parser = subparsers.add_parser(
@@ -133,6 +139,12 @@ search_multi_parser.add_argument(
 search_multi_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
+search_multi_parser.add_argument(
+    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+)
+search_multi_parser.add_argument(
+    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+)
 
 # Summarize log activity command
 summarize_parser = subparsers.add_parser(
@@ -143,6 +155,12 @@ summarize_parser.add_argument(
 )
 summarize_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
+)
+summarize_parser.add_argument(
+    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+)
+summarize_parser.add_argument(
+    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
 
 # Find error patterns command
@@ -155,6 +173,12 @@ errors_parser.add_argument(
 errors_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
+errors_parser.add_argument(
+    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+)
+errors_parser.add_argument(
+    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+)
 
 # Correlate logs command
 correlate_parser = subparsers.add_parser(
@@ -166,6 +190,12 @@ correlate_parser.add_argument(
 correlate_parser.add_argument("search_term", help="Term to search for in logs")
 correlate_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
+)
+correlate_parser.add_argument(
+    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+)
+correlate_parser.add_argument(
+    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
 
 
@@ -312,55 +342,85 @@ async def main():
                         print("No prompt received.")
 
                 elif args.command == "search":
+                    tool_args = {
+                        "log_group_name": args.log_group_name,
+                        "query": args.query,
+                    }
+                    if args.start_time:
+                        tool_args["start_time"] = args.start_time
+                    if args.end_time:
+                        tool_args["end_time"] = args.end_time
+                    if not (args.start_time or args.end_time):
+                        tool_args["hours"] = args.hours
                     result = await session.call_tool(
                         "search_logs",
-                        arguments={
-                            "log_group_name": args.log_group_name,
-                            "query": args.query,
-                            "hours": args.hours,
-                        },
+                        arguments=tool_args,
                     )
                     print_json_response(result)
 
                 elif args.command == "search-multi":
+                    tool_args = {
+                        "log_group_names": args.log_group_names,
+                        "query": args.query,
+                    }
+                    if args.start_time:
+                        tool_args["start_time"] = args.start_time
+                    if args.end_time:
+                        tool_args["end_time"] = args.end_time
+                    if not (args.start_time or args.end_time):
+                        tool_args["hours"] = args.hours
                     result = await session.call_tool(
                         "search_logs_multi",
-                        arguments={
-                            "log_group_names": args.log_group_names,
-                            "query": args.query,
-                            "hours": args.hours,
-                        },
+                        arguments=tool_args,
                     )
                     print_json_response(result)
 
                 elif args.command == "summarize":
+                    tool_args = {
+                        "log_group_name": args.log_group_name,
+                    }
+                    if args.start_time:
+                        tool_args["start_time"] = args.start_time
+                    if args.end_time:
+                        tool_args["end_time"] = args.end_time
+                    if not (args.start_time or args.end_time):
+                        tool_args["hours"] = args.hours
                     result = await session.call_tool(
                         "summarize_log_activity",
-                        arguments={
-                            "log_group_name": args.log_group_name,
-                            "hours": args.hours,
-                        },
+                        arguments=tool_args,
                     )
                     print_json_response(result)
 
                 elif args.command == "find-errors":
+                    tool_args = {
+                        "log_group_name": args.log_group_name,
+                    }
+                    if args.start_time:
+                        tool_args["start_time"] = args.start_time
+                    if args.end_time:
+                        tool_args["end_time"] = args.end_time
+                    if not (args.start_time or args.end_time):
+                        tool_args["hours"] = args.hours
                     result = await session.call_tool(
                         "find_error_patterns",
-                        arguments={
-                            "log_group_name": args.log_group_name,
-                            "hours": args.hours,
-                        },
+                        arguments=tool_args,
                     )
                     print_json_response(result)
 
                 elif args.command == "correlate":
+                    tool_args = {
+                        "log_group_names": args.log_group_names,
+                        "search_term": args.search_term,
+                    }
+                    if args.start_time:
+                        tool_args["start_time"] = args.start_time
+                    if args.end_time:
+                        tool_args["end_time"] = args.end_time
+                    if not (args.start_time or args.end_time):
+                        tool_args["hours"] = args.hours
                     result = await session.call_tool(
                         "correlate_logs",
-                        arguments={
-                            "log_group_names": args.log_group_names,
-                            "search_term": args.search_term,
-                            "hours": args.hours,
-                        },
+                        arguments=tool_args,
                     )
                     print_json_response(result)
 

--- a/src/cw-mcp-server/server.py
+++ b/src/cw-mcp-server/server.py
@@ -217,103 +217,137 @@ async def list_log_groups(
 
 
 @mcp.tool()
-async def search_logs(log_group_name: str, query: str, hours: int = 24) -> str:
+async def search_logs(
+    log_group_name: str,
+    query: str,
+    hours: int = 24,
+    start_time: str = None,
+    end_time: str = None,
+) -> str:
     """
     Search logs using CloudWatch Logs Insights query.
-
     Args:
         log_group_name: The log group to search
         query: CloudWatch Logs Insights query syntax
         hours: Number of hours to look back
-
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with search results
     """
-    return await search_tools.search_logs(log_group_name, query, hours)
+    return await search_tools.search_logs(
+        log_group_name, query, hours, start_time, end_time
+    )
 
 
 @mcp.tool()
 async def search_logs_multi(
-    log_group_names: List[str], query: str, hours: int = 24
+    log_group_names: List[str],
+    query: str,
+    hours: int = 24,
+    start_time: str = None,
+    end_time: str = None,
 ) -> str:
     """
     Search logs across multiple log groups using CloudWatch Logs Insights.
-    
     Args:
         log_group_names: List of log groups to search
         query: CloudWatch Logs Insights query in Logs Insights syntax
         hours: Number of hours to look back (default: 24)
-    
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with search results
     """
-    return await search_tools.search_logs_multi(log_group_names, query, hours)
+    return await search_tools.search_logs_multi(
+        log_group_names, query, hours, start_time, end_time
+    )
 
 
 @mcp.tool()
 async def filter_log_events(
-    log_group_name: str, filter_pattern: str, hours: int = 24
+    log_group_name: str,
+    filter_pattern: str,
+    hours: int = 24,
+    start_time: str = None,
+    end_time: str = None,
 ) -> str:
     """
     Filter log events by pattern across all streams in a log group.
-
     Args:
         log_group_name: The log group to filter
         filter_pattern: The pattern to search for (CloudWatch Logs filter syntax)
         hours: Number of hours to look back
-
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with filtered events
     """
-    return await search_tools.filter_log_events(log_group_name, filter_pattern, hours)
+    return await search_tools.filter_log_events(
+        log_group_name, filter_pattern, hours, start_time, end_time
+    )
 
 
 @mcp.tool()
-async def summarize_log_activity(log_group_name: str, hours: int = 24) -> str:
+async def summarize_log_activity(
+    log_group_name: str, hours: int = 24, start_time: str = None, end_time: str = None
+) -> str:
     """
     Generate a summary of log activity over a specified time period.
-
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
-
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with activity summary
     """
-    return await analysis_tools.summarize_log_activity(log_group_name, hours)
+    return await analysis_tools.summarize_log_activity(
+        log_group_name, hours, start_time, end_time
+    )
 
 
 @mcp.tool()
-async def find_error_patterns(log_group_name: str, hours: int = 24) -> str:
+async def find_error_patterns(
+    log_group_name: str, hours: int = 24, start_time: str = None, end_time: str = None
+) -> str:
     """
     Find common error patterns in logs.
-
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
-
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with error patterns
     """
-    return await analysis_tools.find_error_patterns(log_group_name, hours)
+    return await analysis_tools.find_error_patterns(
+        log_group_name, hours, start_time, end_time
+    )
 
 
 @mcp.tool()
 async def correlate_logs(
-    log_group_names: List[str], search_term: str, hours: int = 24
+    log_group_names: List[str],
+    search_term: str,
+    hours: int = 24,
+    start_time: str = None,
+    end_time: str = None,
 ) -> str:
     """
     Correlate logs across multiple AWS services using a common search term.
-
     Args:
         log_group_names: List of log group names to search
         search_term: Term to search for in logs (request ID, transaction ID, etc.)
         hours: Number of hours to look back
-
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
     Returns:
         JSON string with correlated events
     """
-    return await correlation_tools.correlate_logs(log_group_names, search_term, hours)
+    return await correlation_tools.correlate_logs(
+        log_group_names, search_term, hours, start_time, end_time
+    )
 
 
 if __name__ == "__main__":

--- a/src/cw-mcp-server/tools/analysis_tools.py
+++ b/src/cw-mcp-server/tools/analysis_tools.py
@@ -6,10 +6,10 @@
 import asyncio
 import boto3
 import json
-from datetime import datetime, timedelta
-import dateutil.parser
+from datetime import datetime
 
 from . import handle_exceptions
+from .utils import get_time_range
 
 
 class CloudWatchLogsAnalysisTools:
@@ -19,17 +19,6 @@ class CloudWatchLogsAnalysisTools:
         """Initialize the CloudWatch Logs client."""
         # Initialize boto3 CloudWatch Logs client using default credential chain
         self.logs_client = boto3.client("logs")
-
-    def _get_time_range(self, hours: int, start_time: str = None, end_time: str = None):
-        if start_time:
-            start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
-        else:
-            start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
-        if end_time:
-            end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
-        else:
-            end_ts = int(datetime.now().timestamp() * 1000)
-        return start_ts, end_ts
 
     @handle_exceptions
     async def summarize_log_activity(
@@ -51,7 +40,7 @@ class CloudWatchLogsAnalysisTools:
         Returns:
             JSON string with activity summary
         """
-        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
+        start_ts, end_ts = get_time_range(hours, start_time, end_time)
 
         # Use CloudWatch Logs Insights to get a summary
         query = """
@@ -156,7 +145,7 @@ class CloudWatchLogsAnalysisTools:
         Returns:
             JSON string with error patterns
         """
-        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
+        start_ts, end_ts = get_time_range(hours, start_time, end_time)
 
         # Query for error logs
         error_query = """

--- a/src/cw-mcp-server/tools/correlation_tools.py
+++ b/src/cw-mcp-server/tools/correlation_tools.py
@@ -7,11 +7,11 @@ import asyncio
 import boto3
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List
-import dateutil.parser
 
 from . import handle_exceptions
+from .utils import get_time_range
 
 
 class CloudWatchLogsCorrelationTools:
@@ -21,17 +21,6 @@ class CloudWatchLogsCorrelationTools:
         """Initialize the CloudWatch Logs client."""
         # Initialize boto3 CloudWatch Logs client using default credential chain
         self.logs_client = boto3.client("logs")
-
-    def _get_time_range(self, hours: int, start_time: str = None, end_time: str = None):
-        if start_time:
-            start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
-        else:
-            start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
-        if end_time:
-            end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
-        else:
-            end_ts = int(datetime.now().timestamp() * 1000)
-        return start_ts, end_ts
 
     @handle_exceptions
     async def correlate_logs(
@@ -55,7 +44,7 @@ class CloudWatchLogsCorrelationTools:
         Returns:
             JSON string with correlated events
         """
-        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
+        start_ts, end_ts = get_time_range(hours, start_time, end_time)
 
         # Validate inputs
         if not log_group_names:

--- a/src/cw-mcp-server/tools/correlation_tools.py
+++ b/src/cw-mcp-server/tools/correlation_tools.py
@@ -9,6 +9,7 @@ import json
 import time
 from datetime import datetime, timedelta
 from typing import List
+import dateutil.parser
 
 from . import handle_exceptions
 
@@ -21,9 +22,25 @@ class CloudWatchLogsCorrelationTools:
         # Initialize boto3 CloudWatch Logs client using default credential chain
         self.logs_client = boto3.client("logs")
 
+    def _get_time_range(self, hours: int, start_time: str = None, end_time: str = None):
+        if start_time:
+            start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
+        else:
+            start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
+        if end_time:
+            end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
+        else:
+            end_ts = int(datetime.now().timestamp() * 1000)
+        return start_ts, end_ts
+
     @handle_exceptions
     async def correlate_logs(
-        self, log_group_names: List[str], search_term: str, hours: int = 24
+        self,
+        log_group_names: List[str],
+        search_term: str,
+        hours: int = 24,
+        start_time: str = None,
+        end_time: str = None,
     ) -> str:
         """
         Correlate logs across multiple AWS services using a common search term.
@@ -32,13 +49,13 @@ class CloudWatchLogsCorrelationTools:
             log_group_names: List of log group names to search
             search_term: Term to search for in logs (request ID, transaction ID, etc.)
             hours: Number of hours to look back
+            start_time: Start time in ISO8601 format
+            end_time: End time in ISO8601 format
 
         Returns:
             JSON string with correlated events
         """
-        # Calculate time range
-        end_time = int(datetime.now().timestamp() * 1000)
-        start_time = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
+        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
 
         # Validate inputs
         if not log_group_names:
@@ -54,8 +71,8 @@ class CloudWatchLogsCorrelationTools:
         # Results dictionary
         results = {
             "timeRange": {
-                "start": datetime.fromtimestamp(start_time / 1000).isoformat(),
-                "end": datetime.fromtimestamp(end_time / 1000).isoformat(),
+                "start": datetime.fromtimestamp(start_ts / 1000).isoformat(),
+                "end": datetime.fromtimestamp(end_ts / 1000).isoformat(),
                 "hours": hours,
             },
             "searchTerm": search_term,
@@ -75,8 +92,8 @@ class CloudWatchLogsCorrelationTools:
             # Start the query
             start_query_response = self.logs_client.start_query(
                 logGroupName=log_group_name,
-                startTime=start_time,
-                endTime=end_time,
+                startTime=start_ts,
+                endTime=end_ts,
                 queryString=query,
             )
 
@@ -91,7 +108,7 @@ class CloudWatchLogsCorrelationTools:
                 # Avoid long-running queries
                 if response["status"] == "Running":
                     # Check if we've been running too long (30 seconds)
-                    if time.time() * 1000 - end_time > 30000:
+                    if time.time() * 1000 - end_ts > 30000:
                         response = {"status": "Timeout", "results": []}
                         break
 

--- a/src/cw-mcp-server/tools/search_tools.py
+++ b/src/cw-mcp-server/tools/search_tools.py
@@ -7,11 +7,11 @@ import asyncio
 import boto3
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List
-import dateutil.parser
 
 from . import handle_exceptions
+from .utils import get_time_range
 
 
 class CloudWatchLogsSearchTools:
@@ -21,17 +21,6 @@ class CloudWatchLogsSearchTools:
         """Initialize the CloudWatch Logs client."""
         # Initialize boto3 CloudWatch Logs client using default credential chain
         self.logs_client = boto3.client("logs")
-
-    def _get_time_range(self, hours: int, start_time: str = None, end_time: str = None):
-        if start_time:
-            start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
-        else:
-            start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
-        if end_time:
-            end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
-        else:
-            end_ts = int(datetime.now().timestamp() * 1000)
-        return start_ts, end_ts
 
     @handle_exceptions
     async def search_logs(
@@ -81,7 +70,7 @@ class CloudWatchLogsSearchTools:
         Returns:
             JSON string with search results
         """
-        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
+        start_ts, end_ts = get_time_range(hours, start_time, end_time)
         # Start the query
         start_query_response = self.logs_client.start_query(
             logGroupNames=log_group_names,
@@ -148,7 +137,7 @@ class CloudWatchLogsSearchTools:
         Returns:
             JSON string with filtered events
         """
-        start_ts, end_ts = self._get_time_range(hours, start_time, end_time)
+        start_ts, end_ts = get_time_range(hours, start_time, end_time)
         response = self.logs_client.filter_log_events(
             logGroupName=log_group_name,
             filterPattern=filter_pattern,

--- a/src/cw-mcp-server/tools/utils.py
+++ b/src/cw-mcp-server/tools/utils.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime, timedelta
+import dateutil.parser
+
+
+def get_time_range(hours: int, start_time: str = None, end_time: str = None):
+    """
+    Calculate time range timestamps from hours or exact start/end times.
+
+    Args:
+        hours: Number of hours to look back (used if start_time is not provided)
+        start_time: Optional ISO8601 start time
+        end_time: Optional ISO8601 end time
+
+    Returns:
+        Tuple of (start_timestamp, end_timestamp) in milliseconds since epoch
+    """
+    if start_time:
+        start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
+    else:
+        start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
+
+    if end_time:
+        end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
+    else:
+        end_ts = int(datetime.now().timestamp() * 1000)
+
+    return start_ts, end_ts

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.37.11" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.3.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -192,13 +192,14 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b6/81e5f2490290351fc97bf46c24ff935128cb7d34d68e3987b522f26f7ada/mcp-1.3.0.tar.gz", hash = "sha256:f409ae4482ce9d53e7ac03f3f7808bcab735bdfc0fba937453782efb43882d45", size = 150235 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ae/588691c45b38f4fbac07fa3d6d50cea44cc6b35d16ddfdf26e17a0467ab2/mcp-1.7.1.tar.gz", hash = "sha256:eb4f1f53bd717f75dda8a1416e00804b831a8f3c331e23447a03b78f04b43a6e", size = 230903 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/d2/a9e87b506b2094f5aa9becc1af5178842701b27217fa43877353da2577e3/mcp-1.3.0-py3-none-any.whl", hash = "sha256:2829d67ce339a249f803f22eba5e90385eafcac45c94b00cab6cef7e8f217211", size = 70672 },
+    { url = "https://files.pythonhosted.org/packages/ae/79/fe0e20c3358997a80911af51bad927b5ea2f343ef95ab092b19c9cc48b59/mcp-1.7.1-py3-none-any.whl", hash = "sha256:f7e6108977db6d03418495426c7ace085ba2341b75197f8727f96f9cfd30057a", size = 100365 },
 ]
 
 [package.optional-dependencies]
@@ -310,6 +311,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546 },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #8 

## Summary

### Changes

This PR adds support for querying CloudWatch logs using exact start and end date/time (ISO8601 format) in addition to the existing relative hours option. The CLI, server tool handlers, and tool classes now accept optional `start_time` and `end_time` parameters for all relevant log query commands and methods.

### User experience

**Before:**  
Users could only query logs using a relative time window (e.g., `--hours 6`).  

**After:**  
Users can now specify an exact time range using `--start-time` and `--end-time` (e.g., `--start-time 2024-06-01T00:00:00Z --end-time 2024-06-01T12:00:00Z`). If not provided, the original `--hours` option is still supported.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No

**RFC issue number**:

Checklist:

* [x] Migration process documented (not needed, fully backward compatible)
* [x] Implement warnings (not needed, fully backward compatible)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).