### PR TITLE
Add AWS profile support for CloudWatch logs integration

### DIFF
--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -1,6 +1,6 @@
 # 🔐 AWS Configuration Guide
 
-For the MCP server to access your AWS CloudWatch Logs, you need to configure AWS credentials, which you can learn how to do [here](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html). The server uses boto3's default credential resolution chain, which checks several locations in the following order:
+For the MCP server to access your AWS CloudWatch Logs, you need to configure AWS credentials, which you can learn how to do [here](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html). The server uses boto3's credential resolution chain, which checks several locations in the following order:
 
 1. **Environment variables**:
    ```bash
@@ -27,6 +27,16 @@ You can set up your AWS credentials using the AWS CLI:
 ```bash
 aws configure
 ```
+
+## Using a Specific AWS Profile
+
+If you have multiple AWS profiles configured, you can specify which profile to use when starting the MCP server:
+
+```bash
+python src/cw-mcp-server/server.py --profile your-profile-name
+```
+
+This is useful when you need to access CloudWatch logs in different AWS accounts or regions.
 
 ## 🛡️ Required Permissions
 

--- a/src/client.py
+++ b/src/client.py
@@ -14,6 +14,7 @@ from mcp.client.stdio import stdio_client
 
 # Set up argument parser for the CLI
 parser = argparse.ArgumentParser(description="CloudWatch Logs MCP Client")
+parser.add_argument("--profile", type=str, help="AWS profile name to use for credentials")
 subparsers = parser.add_subparsers(dest="command", help="Command to execute")
 
 # List log groups command
@@ -207,9 +208,14 @@ async def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     server_path = os.path.join(script_dir, "cw-mcp-server", "server.py")
 
+    # Prepare server arguments
+    server_args = [server_path]
+    if args.profile:
+        server_args.extend(["--profile", args.profile])
+
     # Create server parameters
     server_params = StdioServerParameters(
-        command="python3", args=[server_path], env=None
+        command="python3", args=server_args, env=None
     )
 
     # Connect to the server

--- a/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
+++ b/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
@@ -14,10 +14,15 @@ from collections import Counter
 class CloudWatchLogsResource:
     """Resource class for handling CloudWatch Logs resources."""
 
-    def __init__(self):
-        """Initialize the CloudWatch Logs resource client."""
-        # Initialize boto3 CloudWatch Logs client using default credential chain
-        self.logs_client = boto3.client("logs")
+    def __init__(self, profile_name=None):
+        """Initialize the CloudWatch Logs resource client.
+        
+        Args:
+            profile_name: Optional AWS profile name to use for credentials
+        """
+        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        session = boto3.Session(profile_name=profile_name)
+        self.logs_client = session.client("logs")
 
     def get_log_groups(
         self, prefix: str = None, limit: int = 50, next_token: str = None
@@ -85,7 +90,8 @@ class CloudWatchLogsResource:
                 retention = f"{log_group['retentionInDays']} days"
 
             # Get metrics for the log group
-            cloudwatch = boto3.client("cloudwatch")
+            session = boto3.Session(profile_name=getattr(self, 'profile_name', None))
+            cloudwatch = session.client("cloudwatch")
             end_time = datetime.utcnow()
             start_time = end_time - timedelta(days=1)
 
@@ -318,7 +324,8 @@ class CloudWatchLogsResource:
         """Get log volume metrics for a log group."""
         try:
             # Create CloudWatch client
-            cloudwatch = boto3.client("cloudwatch")
+            session = boto3.Session(profile_name=getattr(self, 'profile_name', None))
+            cloudwatch = session.client("cloudwatch")
 
             # Calculate start and end times
             end_time = datetime.utcnow()

--- a/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
+++ b/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
@@ -20,6 +20,9 @@ class CloudWatchLogsResource:
         Args:
             profile_name: Optional AWS profile name to use for credentials
         """
+        # Store the profile name for later use
+        self.profile_name = profile_name
+        
         # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
         session = boto3.Session(profile_name=profile_name)
         self.logs_client = session.client("logs")
@@ -90,7 +93,7 @@ class CloudWatchLogsResource:
                 retention = f"{log_group['retentionInDays']} days"
 
             # Get metrics for the log group
-            session = boto3.Session(profile_name=getattr(self, 'profile_name', None))
+            session = boto3.Session(profile_name=self.profile_name)
             cloudwatch = session.client("cloudwatch")
             end_time = datetime.utcnow()
             start_time = end_time - timedelta(days=1)
@@ -324,7 +327,7 @@ class CloudWatchLogsResource:
         """Get log volume metrics for a log group."""
         try:
             # Create CloudWatch client
-            session = boto3.Session(profile_name=getattr(self, 'profile_name', None))
+            session = boto3.Session(profile_name=self.profile_name)
             cloudwatch = session.client("cloudwatch")
 
             # Calculate start and end times

--- a/src/cw-mcp-server/server.py
+++ b/src/cw-mcp-server/server.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+import argparse
 from typing import List
 
 from mcp.server.fastmcp import FastMCP
@@ -13,6 +14,11 @@ from tools.search_tools import CloudWatchLogsSearchTools
 from tools.analysis_tools import CloudWatchLogsAnalysisTools
 from tools.correlation_tools import CloudWatchLogsCorrelationTools
 
+# Parse command line arguments
+parser = argparse.ArgumentParser(description='CloudWatch Logs Analyzer MCP Server')
+parser.add_argument('--profile', type=str, help='AWS profile name to use for credentials')
+args, unknown = parser.parse_known_args()
+
 # Add the current directory to the path so we can import our modules
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
@@ -20,11 +26,11 @@ sys.path.append(current_dir)
 # Create the MCP server for CloudWatch logs
 mcp = FastMCP("CloudWatch Logs Analyzer")
 
-# Initialize our resource and tools classes
-cw_resource = CloudWatchLogsResource()
-search_tools = CloudWatchLogsSearchTools()
-analysis_tools = CloudWatchLogsAnalysisTools()
-correlation_tools = CloudWatchLogsCorrelationTools()
+# Initialize our resource and tools classes with the specified AWS profile
+cw_resource = CloudWatchLogsResource(profile_name=args.profile)
+search_tools = CloudWatchLogsSearchTools(profile_name=args.profile)
+analysis_tools = CloudWatchLogsAnalysisTools(profile_name=args.profile)
+correlation_tools = CloudWatchLogsCorrelationTools(profile_name=args.profile)
 
 # ==============================
 # Resource Handlers

--- a/src/cw-mcp-server/tools/analysis_tools.py
+++ b/src/cw-mcp-server/tools/analysis_tools.py
@@ -15,10 +15,16 @@ from .utils import get_time_range
 class CloudWatchLogsAnalysisTools:
     """Tools for analyzing CloudWatch Logs data."""
 
-    def __init__(self):
-        """Initialize the CloudWatch Logs client."""
-        # Initialize boto3 CloudWatch Logs client using default credential chain
-        self.logs_client = boto3.client("logs")
+    def __init__(self, profile_name=None):
+        """Initialize the CloudWatch Logs client.
+        
+        Args:
+            profile_name: Optional AWS profile name to use for credentials
+        """
+        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        self.profile_name = profile_name
+        session = boto3.Session(profile_name=profile_name)
+        self.logs_client = session.client("logs")
 
     @handle_exceptions
     async def summarize_log_activity(

--- a/src/cw-mcp-server/tools/correlation_tools.py
+++ b/src/cw-mcp-server/tools/correlation_tools.py
@@ -17,10 +17,16 @@ from .utils import get_time_range
 class CloudWatchLogsCorrelationTools:
     """Tools for correlating logs across multiple CloudWatch Log groups."""
 
-    def __init__(self):
-        """Initialize the CloudWatch Logs client."""
-        # Initialize boto3 CloudWatch Logs client using default credential chain
-        self.logs_client = boto3.client("logs")
+    def __init__(self, profile_name=None):
+        """Initialize the CloudWatch Logs client.
+        
+        Args:
+            profile_name: Optional AWS profile name to use for credentials
+        """
+        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        self.profile_name = profile_name
+        session = boto3.Session(profile_name=profile_name)
+        self.logs_client = session.client("logs")
 
     @handle_exceptions
     async def correlate_logs(

--- a/src/cw-mcp-server/tools/search_tools.py
+++ b/src/cw-mcp-server/tools/search_tools.py
@@ -17,10 +17,16 @@ from .utils import get_time_range
 class CloudWatchLogsSearchTools:
     """Tools for searching and querying CloudWatch Logs."""
 
-    def __init__(self):
-        """Initialize the CloudWatch Logs client."""
-        # Initialize boto3 CloudWatch Logs client using default credential chain
-        self.logs_client = boto3.client("logs")
+    def __init__(self, profile_name=None):
+        """Initialize the CloudWatch Logs client.
+        
+        Args:
+            profile_name: Optional AWS profile name to use for credentials
+        """
+        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        self.profile_name = profile_name
+        session = boto3.Session(profile_name=profile_name)
+        self.logs_client = session.client("logs")
 
     @handle_exceptions
     async def search_logs(


### PR DESCRIPTION
## Summary
- Adds support for specifying an AWS profile when starting the MCP server
- Updates all AWS client initializations to use the specified profile
- Ensures AWS credentials are consistent across all operations
- Improves documentation with usage examples

## Test plan
1. Set up multiple AWS profiles in ~/.aws/credentials
2. Run the server with `--profile your-profile-name`
3. Verify logs can be retrieved from the specified profile
4. Verify all search and analysis tools work with the profile

🤖 Generated with [Claude Code](https://claude.ai/code)