### PR TITLE
docs: add amazon q cli integration details

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -22,6 +22,45 @@ To get Claude for Desktop and how to add an MCP server, access [this link](https
 }
 ```
 
+## 🤖 Amazon Q CLI Integration
+
+Amazon Q CLI acts as an MCP Client. To connect to MCP Servers and access the tools they surface, you need to create a configuration file called `mcp.json` in your Amazon Q configuration directory.
+
+Your directory structure should look like this:
+
+```bash
+~/.aws
+└── amazonq
+    ├── mcp.json
+    ├── profiles
+    ├── cache
+    ├── history
+    └── prompts
+```
+
+If `mcp.json` is empty, edit it to add this to your MCP Server configuration file:
+
+```json
+{
+  "mcpServers": {
+    "cw-mcp-server": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/path/to/Log-Analyzer-with-MCP/src/cw-mcp-server",
+        "run",
+        "server.py"
+      ]
+    }
+  }
+}
+```
+
+### Testing the configuration
+Every time you start Amazon Q CLI, it will attempt to load any configured MCP Servers. You should see output indicating that the MCP Server has been discovered and initialized.
+
+![image](https://github.com/user-attachments/assets/9acc1632-5a9a-4465-9fdc-a8464640f6a6)
+
 If you're running into issues, check out the [troubleshooting guide](./troubleshooting.md) or open a GitHub Issue. 
 
 ## 🔍 AI Assistant Capabilities

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ if you have issues with your configuration, then Amazon Q CLI will start (withou
 WARNING: Error reading global mcp config: expected value at line 9 column 19
 Please check to make sure config is correct. Discarding.
 ```
-You might also see timeout issues if it is struggling to find and downloaded the details you have configured in your mcp.json, for example:
+You might also see timeout issues if it is struggling to find and download the details you have configured in your mcp.json, for example:
 ```
 x mcp_server has failed to load:
 - Operation timed out: recv for initialization

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,9 +55,9 @@ Please check to make sure config is correct. Discarding.
 You might also see timeout issues if it is struggling to find and downloaded the details you have configured in your mcp.json, for example:
 ```
 x mcp_server has failed to load:
-- Operation timed out: recv for initilization
+- Operation timed out: recv for initialization
 - run with Q_LOG_LEVEL=trace and see $TMPDIR/qlog for detail
-x 0 of 1 mcp servers initilized
+x 0 of 1 mcp servers initialized
 ```
 You can go to `$TMPDIR/qlog` to find various logs generated, and you can configure Q_LOG_LEVEL with either trace, debug, info, and warn configurations to get debug output to help you troubleshoot any issues you might run into.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,6 +45,23 @@ In this case, try checking the server logs as outlined in the settings
 
 then, click on the `Open Logs Folder` and open the `mcp-server-cw-mcp-server.log` file to see more details. 
 
+**Amazon Q CLI terminating request**:
+
+if you have issues with your configuration, then Amazon Q CLI will start (without any MCP Server Tools) with an error similar to:
+```
+WARNING: Error reading global mcp config: expected value at line 9 column 19
+Please check to make sure config is correct. Discarding.
+```
+You might also see timeout issues if it is struggling to find and downloaded the details you have configured in your mcp.json, for example:
+```
+x mcp_server has failed to load:
+- Operation timed out: recv for initilization
+- run with Q_LOG_LEVEL=trace and see $TMPDIR/qlog for detail
+x 0 of 1 mcp servers initilized
+```
+You can go to `$TMPDIR/qlog` to find various logs generated, and you can configure Q_LOG_LEVEL with either trace, debug, info, and warn configurations to get debug output to help you troubleshoot any issues you might run into.
+
+
 ## 🆘 Getting Help
 
 If you encounter issues not covered in this troubleshooting section, please:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

### Changes

> 	Updated troubleshooting.md to include a new “Q CLI Integration” section
	Added instructions on where to place and how to populate the mcp.json file under ~/.aws/amazonq
	Provided an example JSON snippet for registering the MCP Server for amazon q cli
	Clarified how to verify the integration by observing Amazon Q CLI’s startup logs

### User experience

> Improves clarity around configuring Amazon Q CLI as an MCP client and reduces onboarding friction.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?N/A

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).
