### PR TITLE
feat: add region support for AWS API calls in client and server

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -16,6 +16,7 @@ To get Claude for Desktop and how to add an MCP server, access [this link](https
         "/path/to/Log-Analyzer-with-MCP/src/cw-mcp-server",
         "run",
         "server.py"
+        // You can add "--profile", "your-profile" and/or "--region", "us-west-2" here if needed but it will pull it from your AWS credentials as well
       ]
     }
   },
@@ -50,6 +51,7 @@ If `mcp.json` is empty, edit it to add this to your MCP Server configuration fil
         "/path/to/Log-Analyzer-with-MCP/src/cw-mcp-server",
         "run",
         "server.py"
+        // Optionally add "--profile", "your-profile" and/or "--region", "us-west-2" here if needed but it will pull it from your AWS credentials as well
       ]
     }
   }
@@ -87,7 +89,7 @@ With the enhanced tool support, AI assistants can now:
    - "Find correlations between errors in my database and API logs"
    - "Analyze the trend of timeouts in my Lambda function"
 
->If you want to use a different AWS profile, just mention the profile name with your prompt - `"Show me all my CloudWatch log groups using <profile_name> profile"`
+> You can specify a different AWS profile or region in your prompt, e.g. "Show me all my CloudWatch log groups using <profile_name> profile in <region> region"
 
 ## 💬 AI Prompt Templates
 
@@ -104,7 +106,7 @@ The server provides specialized prompts that AI assistants can use:
    Please analyze the following CloudWatch logs from the {log_group_name} log group.
    First, I'll get you some information about the log group...
    ```
-3. **Profile Override**:
+3. **Profile/Region Override**:
    ```
-   I'll help you list CloudWatch log groups using the <profile_name> profile. Let me do that for you:
+   I'll help you list CloudWatch log groups using the <profile_name> profile in the <region> region. Let me do that for you:
    ```

--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -28,24 +28,23 @@ You can set up your AWS credentials using the AWS CLI:
 aws configure
 ```
 
-## Using a Specific AWS Profile
+## Using a Specific AWS Profile or Region
 
 1. **Server Start-up**
 
-   If you have multiple AWS profiles, choose one when you launch the MCP server:
+   If you have multiple AWS profiles or want to specify a region, use:
    
    ```bash
-   python src/cw-mcp-server/server.py --profile your-profile-name
+   python src/cw-mcp-server/server.py --profile your-profile-name --region us-west-2
    ```
 
 2. **Per-Call Override**
 
-   Override the profile on individual AI prompts or tool calls:
+   Override the profile or region on individual AI prompts or tool calls:
    
-   > Example: Get a list of CloudWatch log groups using the "dev-account" profile.
+   > Example: Get a list of CloudWatch log groups using the "dev-account" profile in "eu-central-1" region.
 
-   Once you set a profile, the LLM keeps using it for follow-ups. Only specify a new profile when you need to switch accounts.
-
+   Once you set a profile or region, the LLM keeps using it for follow-ups. Only specify a new profile or region when you need to switch accounts or regions.
 
 This is useful when you need to access CloudWatch logs in different AWS accounts or regions.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ AI assistants can leverage this MCP server. To understand more check out the [AI
 The MCP server exposes CloudWatch logs data and analysis tools to AI assistants and MCP clients:
 
 ```bash
-python src/cw-mcp-server/server.py
+python src/cw-mcp-server/server.py [--profile your-profile] [--region us-west-2]
 ```
 
 The server runs in the foreground by default. To run it in the background, you can use:
@@ -24,44 +24,46 @@ The project includes a command-line client for interacting with the MCP server:
 
 ```bash
 # List available log groups
-python src/client.py list-groups
+python src/client.py list-groups [--profile your-profile] [--region us-west-2]
 
 # List log groups with a prefix filter
-python src/client.py list-groups --prefix "/aws/lambda"
+python src/client.py list-groups --prefix "/aws/lambda" [--region us-west-2]
 
 # Use the tool interface instead of resource
-python src/client.py list-groups --use-tool
+python src/client.py list-groups --use-tool [--region us-west-2]
 
 # Get a prompt for exploring log groups
-python src/client.py list-prompt
+python src/client.py list-prompt [--region us-west-2]
 
 # List log streams in a specific log group
-python src/client.py list-streams "/aws/lambda/my-function"
+python src/client.py list-streams "/aws/lambda/my-function" [--region us-west-2]
 
 # Get log events from a specific stream
-python src/client.py get-events "/aws/lambda/my-function" "2023/06/01/[$LATEST]abcdef123456"
+python src/client.py get-events "/aws/lambda/my-function" "2023/06/01/[$LATEST]abcdef123456" [--region us-west-2]
 
 # Get a sample of recent logs
-python src/client.py sample "/aws/lambda/my-function"
+python src/client.py sample "/aws/lambda/my-function" [--region us-west-2]
 
 # Get recent errors
-python src/client.py recent-errors "/aws/lambda/my-function"
+python src/client.py recent-errors "/aws/lambda/my-function" [--region us-west-2]
 
 # Get log structure analysis
-python src/client.py structure "/aws/lambda/my-function"
+python src/client.py structure "/aws/lambda/my-function" [--region us-west-2]
 
 # Search logs for a specific pattern
-python src/client.py search "/aws/lambda/my-function" "filter @message like 'error'"
+python src/client.py search "/aws/lambda/my-function" "filter @message like 'error'" [--region us-west-2]
 
 # Generate a summary of log activity
-python src/client.py summarize "/aws/lambda/my-function" --hours 48
+python src/client.py summarize "/aws/lambda/my-function" --hours 48 [--region us-west-2]
 
 # Find common error patterns
-python src/client.py find-errors "/aws/lambda/my-function"
+python src/client.py find-errors "/aws/lambda/my-function" [--region us-west-2]
 
 # Correlate logs across multiple services
-python src/client.py correlate "/aws/lambda/service1" "/aws/lambda/service2" "OrderId: 12345"
+python src/client.py correlate "/aws/lambda/service1" "/aws/lambda/service2" "OrderId: 12345" [--region us-west-2]
 ```
+
+*You can use --profile and --region with any command to target a specific AWS account or region.*
 
 ## 🧩 Example Workflows
 
@@ -69,16 +71,16 @@ python src/client.py correlate "/aws/lambda/service1" "/aws/lambda/service2" "Or
 
 ```bash
 # 1. List your log groups to find the Lambda function
-python src/client.py list-groups --prefix "/aws/lambda"
+python src/client.py list-groups --prefix "/aws/lambda" [--region us-west-2]
 
 # 2. Generate a summary to see when errors occurred
-python src/client.py summarize "/aws/lambda/my-function" --hours 24
+python src/client.py summarize "/aws/lambda/my-function" --hours 24 [--region us-west-2]
 
 # 3. Find the most common error patterns
-python src/client.py find-errors "/aws/lambda/my-function"
+python src/client.py find-errors "/aws/lambda/my-function" [--region us-west-2]
 
 # 4. Search for details about a specific error
-python src/client.py search "/aws/lambda/my-function" "filter @message like 'ConnectionError'"
+python src/client.py search "/aws/lambda/my-function" "filter @message like 'ConnectionError'" [--region us-west-2]
 ```
 
 ### Correlating requests across microservices using the standalone server directly
@@ -89,7 +91,7 @@ python src/client.py correlate \
   "/aws/lambda/api-gateway" \
   "/aws/lambda/auth-service" \
   "/aws/lambda/payment-processor" \
-  "req-abc123"
+  "req-abc123" [--region us-west-2]
 ```
 
 ## 🔗 Resource URIs

--- a/src/client.py
+++ b/src/client.py
@@ -17,6 +17,7 @@ parser = argparse.ArgumentParser(description="CloudWatch Logs MCP Client")
 parser.add_argument(
     "--profile", type=str, help="AWS profile name to use for credentials"
 )
+parser.add_argument("--region", type=str, help="AWS region name to use for API calls")
 subparsers = parser.add_subparsers(dest="command", help="Command to execute")
 
 # List log groups command
@@ -36,18 +37,34 @@ list_groups_parser.add_argument(
 list_groups_parser.add_argument(
     "--use-tool", action="store_true", help="Use the tool interface instead of resource"
 )
+list_groups_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+list_groups_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get log group details command
 group_details_parser = subparsers.add_parser(
     "group-details", help="Get detailed information about a log group"
 )
 group_details_parser.add_argument("log_group_name", help="The name of the log group")
+group_details_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+group_details_parser.add_argument(
+    "--region", help="AWS region name to use for API calls"
+)
 
 # List log streams command
 list_streams_parser = subparsers.add_parser(
     "list-streams", help="List log streams for a specific log group"
 )
 list_streams_parser.add_argument("log_group_name", help="The name of the log group")
+list_streams_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+list_streams_parser.add_argument(
+    "--region", help="AWS region name to use for API calls"
+)
 
 # Get log events command
 get_events_parser = subparsers.add_parser(
@@ -55,6 +72,10 @@ get_events_parser = subparsers.add_parser(
 )
 get_events_parser.add_argument("log_group_name", help="The name of the log group")
 get_events_parser.add_argument("log_stream_name", help="The name of the log stream")
+get_events_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+get_events_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get log sample command
 sample_parser = subparsers.add_parser(
@@ -64,6 +85,8 @@ sample_parser.add_argument("log_group_name", help="The name of the log group")
 sample_parser.add_argument(
     "--limit", type=int, default=10, help="Number of logs to sample (default: 10)"
 )
+sample_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+sample_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get recent errors command
 errors_parser = subparsers.add_parser(
@@ -75,6 +98,8 @@ errors_parser.add_argument(
 errors_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
+errors_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+errors_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get log metrics command
 metrics_parser = subparsers.add_parser(
@@ -86,6 +111,8 @@ metrics_parser.add_argument(
 metrics_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
+metrics_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+metrics_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Analyze log structure command
 structure_parser = subparsers.add_parser(
@@ -94,6 +121,10 @@ structure_parser = subparsers.add_parser(
 structure_parser.add_argument(
     "log_group_name", help="The name of the log group to analyze"
 )
+structure_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+structure_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get analyze logs prompt command
 prompt_parser = subparsers.add_parser(
@@ -102,6 +133,8 @@ prompt_parser = subparsers.add_parser(
 prompt_parser.add_argument(
     "log_group_name", help="The name of the log group to analyze"
 )
+prompt_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+prompt_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Get list groups prompt command
 list_prompt_parser = subparsers.add_parser(
@@ -110,6 +143,10 @@ list_prompt_parser = subparsers.add_parser(
 list_prompt_parser.add_argument(
     "--prefix", help="Optional prefix to filter log groups by name"
 )
+list_prompt_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+list_prompt_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Search logs command
 search_parser = subparsers.add_parser(
@@ -128,6 +165,8 @@ search_parser.add_argument(
 search_parser.add_argument(
     "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
+search_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+search_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Search multiple log groups command
 search_multi_parser = subparsers.add_parser(
@@ -148,6 +187,12 @@ search_multi_parser.add_argument(
 search_multi_parser.add_argument(
     "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
+search_multi_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+search_multi_parser.add_argument(
+    "--region", help="AWS region name to use for API calls"
+)
 
 # Summarize log activity command
 summarize_parser = subparsers.add_parser(
@@ -165,6 +210,10 @@ summarize_parser.add_argument(
 summarize_parser.add_argument(
     "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
+summarize_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+summarize_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Find error patterns command
 errors_parser = subparsers.add_parser(
@@ -182,6 +231,8 @@ errors_parser.add_argument(
 errors_parser.add_argument(
     "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
+errors_parser.add_argument("--profile", help="AWS profile name to use for credentials")
+errors_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 # Correlate logs command
 correlate_parser = subparsers.add_parser(
@@ -200,11 +251,23 @@ correlate_parser.add_argument(
 correlate_parser.add_argument(
     "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
 )
+correlate_parser.add_argument(
+    "--profile", help="AWS profile name to use for credentials"
+)
+correlate_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 
 async def main():
     """Main function to run the CloudWatch Logs MCP client."""
     args = parser.parse_args()
+
+    def add_aws_config_args(tool_args):
+        """Add profile and region arguments to tool calls if specified."""
+        if args.profile:
+            tool_args["profile"] = args.profile
+        if args.region:
+            tool_args["region"] = args.region
+        return tool_args
 
     # Determine the server path (relative or absolute)
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -214,6 +277,8 @@ async def main():
     server_args = [server_path]
     if args.profile:
         server_args.extend(["--profile", args.profile])
+    if args.region:
+        server_args.extend(["--region", args.region])
 
     # Create server parameters
     server_params = StdioServerParameters(command="python3", args=server_args, env=None)
@@ -241,6 +306,7 @@ async def main():
                             tool_args["limit"] = args.limit
                         if args.next_token:
                             tool_args["next_token"] = args.next_token
+                        tool_args = add_aws_config_args(tool_args)
 
                         result = await session.call_tool(
                             "list_log_groups", arguments=tool_args
@@ -297,9 +363,11 @@ async def main():
 
                 elif args.command == "get-prompt":
                     # Get the analyze logs prompt from the server
+                    arguments = {"log_group_name": args.log_group_name}
+                    arguments = add_aws_config_args(arguments)
                     result = await session.get_prompt(
                         "analyze_cloudwatch_logs",
-                        arguments={"log_group_name": args.log_group_name},
+                        arguments=arguments,
                     )
 
                     # Extract and print the prompt text
@@ -324,6 +392,7 @@ async def main():
                     arguments = {}
                     if args.prefix:
                         arguments["prefix"] = args.prefix
+                    arguments = add_aws_config_args(arguments)
 
                     # Get the list logs prompt from the server
                     result = await session.get_prompt(
@@ -358,6 +427,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
+                    tool_args = add_aws_config_args(tool_args)
                     result = await session.call_tool(
                         "search_logs",
                         arguments=tool_args,
@@ -375,6 +445,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
+                    tool_args = add_aws_config_args(tool_args)
                     result = await session.call_tool(
                         "search_logs_multi",
                         arguments=tool_args,
@@ -391,6 +462,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
+                    tool_args = add_aws_config_args(tool_args)
                     result = await session.call_tool(
                         "summarize_log_activity",
                         arguments=tool_args,
@@ -407,6 +479,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
+                    tool_args = add_aws_config_args(tool_args)
                     result = await session.call_tool(
                         "find_error_patterns",
                         arguments=tool_args,
@@ -424,6 +497,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
+                    tool_args = add_aws_config_args(tool_args)
                     result = await session.call_tool(
                         "correlate_logs",
                         arguments=tool_args,

--- a/src/client.py
+++ b/src/client.py
@@ -257,17 +257,18 @@ correlate_parser.add_argument(
 correlate_parser.add_argument("--region", help="AWS region name to use for API calls")
 
 
+def add_aws_config_args(tool_args, args):
+    """Add profile and region arguments to tool calls if specified."""
+    if args.profile:
+        tool_args["profile"] = args.profile
+    if args.region:
+        tool_args["region"] = args.region
+    return tool_args
+
+
 async def main():
     """Main function to run the CloudWatch Logs MCP client."""
     args = parser.parse_args()
-
-    def add_aws_config_args(tool_args):
-        """Add profile and region arguments to tool calls if specified."""
-        if args.profile:
-            tool_args["profile"] = args.profile
-        if args.region:
-            tool_args["region"] = args.region
-        return tool_args
 
     # Determine the server path (relative or absolute)
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -306,7 +307,7 @@ async def main():
                             tool_args["limit"] = args.limit
                         if args.next_token:
                             tool_args["next_token"] = args.next_token
-                        tool_args = add_aws_config_args(tool_args)
+                        tool_args = add_aws_config_args(tool_args, args)
 
                         result = await session.call_tool(
                             "list_log_groups", arguments=tool_args
@@ -364,7 +365,7 @@ async def main():
                 elif args.command == "get-prompt":
                     # Get the analyze logs prompt from the server
                     arguments = {"log_group_name": args.log_group_name}
-                    arguments = add_aws_config_args(arguments)
+                    arguments = add_aws_config_args(arguments, args)
                     result = await session.get_prompt(
                         "analyze_cloudwatch_logs",
                         arguments=arguments,
@@ -392,7 +393,7 @@ async def main():
                     arguments = {}
                     if args.prefix:
                         arguments["prefix"] = args.prefix
-                    arguments = add_aws_config_args(arguments)
+                    arguments = add_aws_config_args(arguments, args)
 
                     # Get the list logs prompt from the server
                     result = await session.get_prompt(
@@ -427,7 +428,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
-                    tool_args = add_aws_config_args(tool_args)
+                    tool_args = add_aws_config_args(tool_args, args)
                     result = await session.call_tool(
                         "search_logs",
                         arguments=tool_args,
@@ -445,7 +446,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
-                    tool_args = add_aws_config_args(tool_args)
+                    tool_args = add_aws_config_args(tool_args, args)
                     result = await session.call_tool(
                         "search_logs_multi",
                         arguments=tool_args,
@@ -462,7 +463,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
-                    tool_args = add_aws_config_args(tool_args)
+                    tool_args = add_aws_config_args(tool_args, args)
                     result = await session.call_tool(
                         "summarize_log_activity",
                         arguments=tool_args,
@@ -479,7 +480,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
-                    tool_args = add_aws_config_args(tool_args)
+                    tool_args = add_aws_config_args(tool_args, args)
                     result = await session.call_tool(
                         "find_error_patterns",
                         arguments=tool_args,
@@ -497,7 +498,7 @@ async def main():
                         tool_args["end_time"] = args.end_time
                     if not (args.start_time or args.end_time):
                         tool_args["hours"] = args.hours
-                    tool_args = add_aws_config_args(tool_args)
+                    tool_args = add_aws_config_args(tool_args, args)
                     result = await session.call_tool(
                         "correlate_logs",
                         arguments=tool_args,

--- a/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
+++ b/src/cw-mcp-server/resources/cloudwatch_logs_resource.py
@@ -14,17 +14,19 @@ from collections import Counter
 class CloudWatchLogsResource:
     """Resource class for handling CloudWatch Logs resources."""
 
-    def __init__(self, profile_name=None):
+    def __init__(self, profile_name=None, region_name=None):
         """Initialize the CloudWatch Logs resource client.
 
         Args:
             profile_name: Optional AWS profile name to use for credentials
+            region_name: Optional AWS region name to use for API calls
         """
-        # Store the profile name for later use
+        # Store the profile name and region for later use
         self.profile_name = profile_name
+        self.region_name = region_name
 
-        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
-        session = boto3.Session(profile_name=profile_name)
+        # Initialize boto3 CloudWatch Logs client using specified profile/region or default credential chain
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
         self.logs_client = session.client("logs")
 
     def get_log_groups(
@@ -93,7 +95,9 @@ class CloudWatchLogsResource:
                 retention = f"{log_group['retentionInDays']} days"
 
             # Get metrics for the log group
-            session = boto3.Session(profile_name=self.profile_name)
+            session = boto3.Session(
+                profile_name=self.profile_name, region_name=self.region_name
+            )
             cloudwatch = session.client("cloudwatch")
             end_time = datetime.utcnow()
             start_time = end_time - timedelta(days=1)
@@ -327,7 +331,9 @@ class CloudWatchLogsResource:
         """Get log volume metrics for a log group."""
         try:
             # Create CloudWatch client
-            session = boto3.Session(profile_name=self.profile_name)
+            session = boto3.Session(
+                profile_name=self.profile_name, region_name=self.region_name
+            )
             cloudwatch = session.client("cloudwatch")
 
             # Calculate start and end times

--- a/src/cw-mcp-server/server.py
+++ b/src/cw-mcp-server/server.py
@@ -21,6 +21,7 @@ parser = argparse.ArgumentParser(description="CloudWatch Logs Analyzer MCP Serve
 parser.add_argument(
     "--profile", type=str, help="AWS profile name to use for credentials"
 )
+parser.add_argument("--region", type=str, help="AWS region name to use for API calls")
 args, unknown = parser.parse_known_args()
 
 # Add the current directory to the path so we can import our modules
@@ -30,24 +31,31 @@ sys.path.append(current_dir)
 # Create the MCP server for CloudWatch logs
 mcp = FastMCP("CloudWatch Logs Analyzer")
 
-# Initialize our resource and tools classes with the specified AWS profile
-cw_resource = CloudWatchLogsResource(profile_name=args.profile)
-search_tools = CloudWatchLogsSearchTools(profile_name=args.profile)
-analysis_tools = CloudWatchLogsAnalysisTools(profile_name=args.profile)
-correlation_tools = CloudWatchLogsCorrelationTools(profile_name=args.profile)
+# Initialize our resource and tools classes with the specified AWS profile and region
+cw_resource = CloudWatchLogsResource(profile_name=args.profile, region_name=args.region)
+search_tools = CloudWatchLogsSearchTools(
+    profile_name=args.profile, region_name=args.region
+)
+analysis_tools = CloudWatchLogsAnalysisTools(
+    profile_name=args.profile, region_name=args.region
+)
+correlation_tools = CloudWatchLogsCorrelationTools(
+    profile_name=args.profile, region_name=args.region
+)
 
-# Capture the parsed CLI profile in a separate variable
+# Capture the parsed CLI profile and region in separate variables
 default_profile = args.profile
+default_region = args.region
 
 
-# Helper decorator to handle profile parameter for tools
-def with_profile(tool_class: Type, method_name: Optional[str] = None) -> Callable:
+# Helper decorator to handle profile and region parameters for tools
+def with_aws_config(tool_class: Type, method_name: Optional[str] = None) -> Callable:
     """
-    Decorator that handles the profile parameter for tool functions.
-    Creates a new instance of the specified tool class with the correct profile.
+    Decorator that handles the profile and region parameters for tool functions.
+    Creates a new instance of the specified tool class with the correct profile and region.
 
     Args:
-        tool_class: The class to instantiate with the profile
+        tool_class: The class to instantiate with the profile and region
         method_name: Optional method name if different from the decorated function
     """
 
@@ -56,7 +64,8 @@ def with_profile(tool_class: Type, method_name: Optional[str] = None) -> Callabl
         async def wrapper(*args, **kwargs) -> Any:
             try:
                 profile = kwargs.pop("profile", None) or default_profile
-                tool_instance = tool_class(profile_name=profile)
+                region = kwargs.pop("region", None) or default_region
+                tool_instance = tool_class(profile_name=profile, region_name=region)
                 target_method = method_name or func.__name__
                 method = getattr(tool_instance, target_method)
                 result = method(**kwargs)
@@ -192,21 +201,27 @@ def analyze_log_structure(log_group_name: str) -> str:
 
 
 @mcp.prompt()
-def list_cloudwatch_log_groups(prefix: str = None, profile: str = None) -> str:
+def list_cloudwatch_log_groups(
+    prefix: str = None, profile: str = None, region: str = None
+) -> str:
     """
     Prompt for listing and exploring CloudWatch log groups.
 
     Args:
         prefix: Optional prefix to filter log groups by name
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
     """
-    prefix_text = f" starting with '{prefix}'" if prefix else ""
-    profile_text = f" and using profile '{profile}'" if profile else ""
-    return f"""I'll help you explore the CloudWatch log groups{prefix_text}{profile_text} in your AWS environment    
+    profile_text = f" using profile '{profile}'" if profile else ""
+    region_text = f" in region '{region}'" if region else ""
+    prefix_text = f' with prefix "{prefix}"' if prefix else ""
 
-First, I'll list the available log groups. For each log group, I can help you:
+    return f"""I'll help you explore the CloudWatch log groups in your AWS environment{profile_text}{region_text}.
 
-1. Examine its structure and format
+First, I'll list the available log groups{prefix_text}.
+
+For each log group, I can help you:
+1. Get detailed information about the group (retention, size, etc.)
 2. Check for recent errors or patterns
 3. View metrics like volume and activity
 4. Sample recent logs to understand the content
@@ -217,16 +232,21 @@ Let me know which log group you'd like to explore further, or if you'd like to r
 
 
 @mcp.prompt()
-def analyze_cloudwatch_logs(log_group_name: str, profile: str = None) -> str:
+def analyze_cloudwatch_logs(
+    log_group_name: str, profile: str = None, region: str = None
+) -> str:
     """
     Prompt for analyzing CloudWatch logs to help identify issues, patterns, and insights.
 
     Args:
         log_group_name: The name of the log group to analyze
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
     """
     profile_text = f" using profile '{profile}'" if profile else ""
-    return f"""Please analyze the following CloudWatch logs from the {log_group_name} log group{profile_text}.
+    region_text = f" in region '{region}'" if region else ""
+
+    return f"""Please analyze the following CloudWatch logs from the {log_group_name} log group{profile_text}{region_text}.
 
 First, I'll get you some information about the log group:
 1. Get the basic log group structure to understand the format of logs
@@ -254,9 +274,13 @@ Feel free to ask for additional context if needed, such as:
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsResource, method_name="get_log_groups")
+@with_aws_config(CloudWatchLogsResource, method_name="get_log_groups")
 async def list_log_groups(
-    prefix: str = None, limit: int = 50, next_token: str = None, profile: str = None
+    prefix: str = None,
+    limit: int = 50,
+    next_token: str = None,
+    profile: str = None,
+    region: str = None,
 ) -> str:
     """
     List available CloudWatch log groups with optional filtering by prefix.
@@ -266,6 +290,7 @@ async def list_log_groups(
         limit: Maximum number of log groups to return (default: 50)
         next_token: Token for pagination to get the next set of results
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
 
     Returns:
         JSON string with log groups information
@@ -275,7 +300,7 @@ async def list_log_groups(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsSearchTools)
+@with_aws_config(CloudWatchLogsSearchTools)
 async def search_logs(
     log_group_name: str,
     query: str,
@@ -283,9 +308,11 @@ async def search_logs(
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Search logs using CloudWatch Logs Insights query.
+
     Args:
         log_group_name: The log group to search
         query: CloudWatch Logs Insights query syntax
@@ -293,6 +320,8 @@ async def search_logs(
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with search results
     """
@@ -301,7 +330,7 @@ async def search_logs(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsSearchTools)
+@with_aws_config(CloudWatchLogsSearchTools)
 async def search_logs_multi(
     log_group_names: List[str],
     query: str,
@@ -309,9 +338,11 @@ async def search_logs_multi(
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Search logs across multiple log groups using CloudWatch Logs Insights.
+
     Args:
         log_group_names: List of log groups to search
         query: CloudWatch Logs Insights query in Logs Insights syntax
@@ -319,6 +350,8 @@ async def search_logs_multi(
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with search results
     """
@@ -327,7 +360,7 @@ async def search_logs_multi(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsSearchTools)
+@with_aws_config(CloudWatchLogsSearchTools)
 async def filter_log_events(
     log_group_name: str,
     filter_pattern: str,
@@ -335,9 +368,11 @@ async def filter_log_events(
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Filter log events by pattern across all streams in a log group.
+
     Args:
         log_group_name: The log group to filter
         filter_pattern: The pattern to search for (CloudWatch Logs filter syntax)
@@ -345,6 +380,8 @@ async def filter_log_events(
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with filtered events
     """
@@ -353,22 +390,26 @@ async def filter_log_events(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsAnalysisTools)
+@with_aws_config(CloudWatchLogsAnalysisTools)
 async def summarize_log_activity(
     log_group_name: str,
     hours: int = 24,
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Generate a summary of log activity over a specified time period.
+
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with activity summary
     """
@@ -377,22 +418,26 @@ async def summarize_log_activity(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsAnalysisTools)
+@with_aws_config(CloudWatchLogsAnalysisTools)
 async def find_error_patterns(
     log_group_name: str,
     hours: int = 24,
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Find common error patterns in logs.
+
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with error patterns
     """
@@ -401,7 +446,7 @@ async def find_error_patterns(
 
 
 @mcp.tool()
-@with_profile(CloudWatchLogsCorrelationTools)
+@with_aws_config(CloudWatchLogsCorrelationTools)
 async def correlate_logs(
     log_group_names: List[str],
     search_term: str,
@@ -409,9 +454,11 @@ async def correlate_logs(
     start_time: str = None,
     end_time: str = None,
     profile: str = None,
+    region: str = None,
 ) -> str:
     """
     Correlate logs across multiple AWS services using a common search term.
+
     Args:
         log_group_names: List of log group names to search
         search_term: Term to search for in logs (request ID, transaction ID, etc.)
@@ -419,6 +466,8 @@ async def correlate_logs(
         start_time: Optional ISO8601 start time
         end_time: Optional ISO8601 end time
         profile: Optional AWS profile name to use for credentials
+        region: Optional AWS region name to use for API calls
+
     Returns:
         JSON string with correlated events
     """

--- a/src/cw-mcp-server/server.py
+++ b/src/cw-mcp-server/server.py
@@ -214,7 +214,7 @@ def list_cloudwatch_log_groups(
     """
     profile_text = f" using profile '{profile}'" if profile else ""
     region_text = f" in region '{region}'" if region else ""
-    prefix_text = f' with prefix "{prefix}"' if prefix else ""
+    prefix_text = f" with prefix '{prefix}'" if prefix else ""
 
     return f"""I'll help you explore the CloudWatch log groups in your AWS environment{profile_text}{region_text}.
 

--- a/src/cw-mcp-server/tools/analysis_tools.py
+++ b/src/cw-mcp-server/tools/analysis_tools.py
@@ -15,15 +15,17 @@ from .utils import get_time_range
 class CloudWatchLogsAnalysisTools:
     """Tools for analyzing CloudWatch Logs data."""
 
-    def __init__(self, profile_name=None):
+    def __init__(self, profile_name=None, region_name=None):
         """Initialize the CloudWatch Logs client.
 
         Args:
             profile_name: Optional AWS profile name to use for credentials
+            region_name: Optional AWS region name to use for API calls
         """
-        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        # Initialize boto3 CloudWatch Logs client using specified profile/region or default credential chain
         self.profile_name = profile_name
-        session = boto3.Session(profile_name=profile_name)
+        self.region_name = region_name
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
         self.logs_client = session.client("logs")
 
     @handle_exceptions

--- a/src/cw-mcp-server/tools/correlation_tools.py
+++ b/src/cw-mcp-server/tools/correlation_tools.py
@@ -17,15 +17,17 @@ from .utils import get_time_range
 class CloudWatchLogsCorrelationTools:
     """Tools for correlating logs across multiple CloudWatch Log groups."""
 
-    def __init__(self, profile_name=None):
+    def __init__(self, profile_name=None, region_name=None):
         """Initialize the CloudWatch Logs client.
 
         Args:
             profile_name: Optional AWS profile name to use for credentials
+            region_name: Optional AWS region name to use for API calls
         """
-        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        # Initialize boto3 CloudWatch Logs client using specified profile/region or default credential chain
         self.profile_name = profile_name
-        session = boto3.Session(profile_name=profile_name)
+        self.region_name = region_name
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
         self.logs_client = session.client("logs")
 
     @handle_exceptions

--- a/src/cw-mcp-server/tools/search_tools.py
+++ b/src/cw-mcp-server/tools/search_tools.py
@@ -17,15 +17,17 @@ from .utils import get_time_range
 class CloudWatchLogsSearchTools:
     """Tools for searching and querying CloudWatch Logs."""
 
-    def __init__(self, profile_name=None):
+    def __init__(self, profile_name=None, region_name=None):
         """Initialize the CloudWatch Logs client.
 
         Args:
             profile_name: Optional AWS profile name to use for credentials
+            region_name: Optional AWS region name to use for API calls
         """
-        # Initialize boto3 CloudWatch Logs client using specified profile or default credential chain
+        # Initialize boto3 CloudWatch Logs client using specified profile/region or default credential chain
         self.profile_name = profile_name
-        session = boto3.Session(profile_name=profile_name)
+        self.region_name = region_name
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
         self.logs_client = session.client("logs")
 
     @handle_exceptions


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #21 

## Summary

### Changes

Added comprehensive AWS region support throughout the MCP server and client. Enhanced profile and region parameter handling in prompt functions to ensure consistent text injection without regressions.

### User experience

**Before:** Users could only specify AWS profile via `--profile` parameter. Region was not configurable and defaulted to AWS SDK defaults.

**After:** Users can now specify both `--profile` and `--region` parameters in all commands. All tool calls, prompts, and resource operations respect the specified region configuration, enabling cross-region CloudWatch log analysis.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**: N/A

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).