### PR TITLE
Fix/client json parsing error

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -510,14 +510,18 @@ async def main():
                 sys.exit(1)
 
 
-def print_json_response(content: str):
+def print_json_response(content: str | tuple):
     """Print JSON content in a formatted way."""
     try:
+        # Handle if content is already a tuple (from read_resource)
+        if isinstance(content, tuple) and len(content) > 0:
+            content = content[0]
+
         # Parse the JSON content and print it in a pretty format
         parsed = json.loads(content)
         print(json.dumps(parsed, indent=2))
-    except json.JSONDecodeError:
-        # If it's not valid JSON, print it as is
+    except (json.JSONDecodeError, TypeError):
+        # If it's not valid JSON or not a string, print it as is
         print(content)
 
 

--- a/src/client.py
+++ b/src/client.py
@@ -510,18 +510,82 @@ async def main():
                 sys.exit(1)
 
 
-def print_json_response(content: str | tuple):
-    """Print JSON content in a formatted way."""
-    try:
-        # Handle if content is already a tuple (from read_resource)
-        if isinstance(content, tuple) and len(content) > 0:
-            content = content[0]
+def print_json_response(content: str | tuple | object | None):
+    """Print JSON content in a formatted way.
 
-        # Parse the JSON content and print it in a pretty format
-        parsed = json.loads(content)
-        print(json.dumps(parsed, indent=2))
-    except (json.JSONDecodeError, TypeError):
-        # If it's not valid JSON or not a string, print it as is
+    Args:
+        content: The content to print, which could be:
+            - String (direct JSON content)
+            - Tuple (from read_resource, where the first element is the content)
+            - Object with .content or .text attributes (from CallToolResult)
+            - None
+    """
+    try:
+        # Handle None case
+        if content is None:
+            print("No content received.")
+            return
+
+        # For Session.read_resource responses, which returns tuple (meta, content)
+        # but we found that sometimes content is None
+        if isinstance(content, tuple):
+            meta, content_text = (
+                content
+                if len(content) >= 2
+                else (content[0] if len(content) == 1 else None, None)
+            )
+
+            # If we have usable content in the second element, use it
+            if content_text is not None:
+                content = content_text
+            # Otherwise, if meta looks usable, try that
+            elif isinstance(meta, str) and meta != "meta":
+                content = meta
+            # We don't have usable content in the tuple
+            else:
+                print("No usable content found in the response.")
+                return
+
+        # Handle object with content attribute (from CallToolResult)
+        if hasattr(content, "content"):
+            content = content.content
+
+        # Handle object with text attribute
+        if hasattr(content, "text"):
+            content = content.text
+
+        # Handle CallToolResult content from mcp_types which can be a list
+        if isinstance(content, list) and all(hasattr(item, "text") for item in content):
+            # Extract text from each item
+            extracted_texts = [item.text for item in content if item.text]
+            if extracted_texts:
+                content = extracted_texts[0]  # Use the first text element
+
+        # Handle if content is a custom object with __str__ method
+        if not isinstance(content, (str, bytes, bytearray)) and hasattr(
+            content, "__str__"
+        ):
+            content = str(content)
+
+        # Try to handle various formats
+        if isinstance(content, str):
+            try:
+                # Try to parse as JSON
+                parsed = json.loads(content)
+                print(json.dumps(parsed, indent=2))
+            except json.JSONDecodeError:
+                # Not valid JSON, just print the string
+                print(content)
+        elif isinstance(content, (dict, list)):
+            # Direct Python objects
+            print(json.dumps(content, indent=2, default=lambda x: str(x)))
+        else:
+            # Fall back to string representation
+            print(content)
+
+    except Exception as e:
+        # Catch-all for any unexpected errors
+        print(f"Error processing response: {e}")
         print(content)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #24 

## Summary

### Changes

> Refactored the `print_json_response` function in `src/client.py` to robustly handle various response types (including tuples, objects with `.content`/`.text`, lists, and None) when printing server responses. This change addresses a bug where the CLI would throw an error if the response was not a string, specifically when a tuple was returned from `read_resource`.

### User experience

> **Before:**  
> Users would encounter an error (`the JSON object must be str, bytes or bytearray, not tuple`) when running commands like `python src/client.py list-groups` if the server response was a tuple, resulting in a stack trace and no usable output.
>
> **After:**  
> The CLI now gracefully handles and prints all valid server responses, regardless of their type. Users will see the expected output or a clear message if the response is empty or malformed, with no stack traces.

The preferred way of usage is `python src/client.py list-groups --use-tool` versus `python src/client.py list-groups`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/Log-Analyzer-with-MCP/blob/main/LICENSE).