### PR TITLE
fix(utils): interpret naive ISO timestamps as UTC in get_time_range

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,6 +84,22 @@ python src/client.py correlate "/aws/lambda/service1" "/aws/lambda/service2" "Or
 
 *You can use --profile and --region with any command to target a specific AWS account or region.*
 
+## 🕐 Time ranges & timezones
+
+Tools and CLI commands that accept `--start-time` / `--end-time` parse ISO8601
+timestamps. The timezone convention is:
+
+- **Naive timestamps** (no `Z` suffix and no offset, e.g. `2025-01-01T00:00:00`)
+  are interpreted as **UTC**. This makes results independent of the server's
+  local timezone — the same input always maps to the same instant.
+- **Offset-aware timestamps** are honored as written, e.g. `2025-01-01T00:00:00Z`
+  (UTC) or `2025-01-01T09:00:00+09:00` (Asia/Tokyo, which is `00:00:00Z`).
+- When `--start-time` is omitted, the range is computed as the last `--hours`
+  hours relative to the current time in UTC.
+
+To target a local wall-clock time, include an explicit offset (e.g.
+`2025-01-01T09:00:00+09:00`) rather than relying on the server's timezone.
+
 ## 🧩 Example Workflows
 
 ### Finding and analyzing errors in a Lambda function using the standalone server directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,12 @@ authors = [
 dependencies = [
     "boto3>=1.37.11",
     "mcp[cli]>=1.6.0",
+    "python-dateutil>=2.9",
 ]
 
 [dependency-groups]
 dev = [
+    "pytest>=8.3",
     "ruff>=0.11.10",
 ]
 

--- a/src/client.py
+++ b/src/client.py
@@ -160,10 +160,14 @@ search_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 search_parser.add_argument(
-    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+    "--start-time",
+    type=str,
+    help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z); naive values are treated as UTC",
 )
 search_parser.add_argument(
-    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+    "--end-time",
+    type=str,
+    help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z); naive values are treated as UTC",
 )
 search_parser.add_argument("--profile", help="AWS profile name to use for credentials")
 search_parser.add_argument("--region", help="AWS region name to use for API calls")
@@ -182,10 +186,14 @@ search_multi_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 search_multi_parser.add_argument(
-    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+    "--start-time",
+    type=str,
+    help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z); naive values are treated as UTC",
 )
 search_multi_parser.add_argument(
-    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+    "--end-time",
+    type=str,
+    help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z); naive values are treated as UTC",
 )
 search_multi_parser.add_argument(
     "--profile", help="AWS profile name to use for credentials"
@@ -205,10 +213,14 @@ summarize_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 summarize_parser.add_argument(
-    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+    "--start-time",
+    type=str,
+    help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z); naive values are treated as UTC",
 )
 summarize_parser.add_argument(
-    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+    "--end-time",
+    type=str,
+    help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z); naive values are treated as UTC",
 )
 summarize_parser.add_argument(
     "--profile", help="AWS profile name to use for credentials"
@@ -226,10 +238,14 @@ errors_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 errors_parser.add_argument(
-    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+    "--start-time",
+    type=str,
+    help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z); naive values are treated as UTC",
 )
 errors_parser.add_argument(
-    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+    "--end-time",
+    type=str,
+    help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z); naive values are treated as UTC",
 )
 errors_parser.add_argument("--profile", help="AWS profile name to use for credentials")
 errors_parser.add_argument("--region", help="AWS region name to use for API calls")
@@ -246,10 +262,14 @@ correlate_parser.add_argument(
     "--hours", type=int, default=24, help="Number of hours to look back (default: 24)"
 )
 correlate_parser.add_argument(
-    "--start-time", type=str, help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z)"
+    "--start-time",
+    type=str,
+    help="Start time (ISO8601, e.g. 2024-06-01T00:00:00Z); naive values are treated as UTC",
 )
 correlate_parser.add_argument(
-    "--end-time", type=str, help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z)"
+    "--end-time",
+    type=str,
+    help="End time (ISO8601, e.g. 2024-06-01T23:59:59Z); naive values are treated as UTC",
 )
 correlate_parser.add_argument(
     "--profile", help="AWS profile name to use for credentials"

--- a/src/cw_mcp_server/server.py
+++ b/src/cw_mcp_server/server.py
@@ -316,8 +316,10 @@ async def search_logs(
         log_group_name: The log group to search
         query: CloudWatch Logs Insights query syntax
         hours: Number of hours to look back
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 
@@ -346,8 +348,10 @@ async def search_logs_multi(
         log_group_names: List of log groups to search
         query: CloudWatch Logs Insights query in Logs Insights syntax
         hours: Number of hours to look back (default: 24)
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 
@@ -376,8 +380,10 @@ async def filter_log_events(
         log_group_name: The log group to filter
         filter_pattern: The pattern to search for (CloudWatch Logs filter syntax)
         hours: Number of hours to look back
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 
@@ -404,8 +410,10 @@ async def summarize_log_activity(
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 
@@ -432,8 +440,10 @@ async def find_error_patterns(
     Args:
         log_group_name: The log group to analyze
         hours: Number of hours to look back
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 
@@ -462,8 +472,10 @@ async def correlate_logs(
         log_group_names: List of log group names to search
         search_term: Term to search for in logs (request ID, transaction ID, etc.)
         hours: Number of hours to look back
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets (e.g. "Z" or "+09:00") are honored.
         profile: Optional AWS profile name to use for credentials
         region: Optional AWS region name to use for API calls
 

--- a/src/cw_mcp_server/tools/analysis_tools.py
+++ b/src/cw_mcp_server/tools/analysis_tools.py
@@ -42,8 +42,10 @@ class CloudWatchLogsAnalysisTools:
         Args:
             log_group_name: The log group to analyze
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with activity summary
@@ -147,8 +149,10 @@ class CloudWatchLogsAnalysisTools:
         Args:
             log_group_name: The log group to analyze
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with error patterns

--- a/src/cw_mcp_server/tools/correlation_tools.py
+++ b/src/cw_mcp_server/tools/correlation_tools.py
@@ -46,8 +46,10 @@ class CloudWatchLogsCorrelationTools:
             log_group_names: List of log group names to search
             search_term: Term to search for in logs (request ID, transaction ID, etc.)
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with correlated events

--- a/src/cw_mcp_server/tools/search_tools.py
+++ b/src/cw_mcp_server/tools/search_tools.py
@@ -46,8 +46,10 @@ class CloudWatchLogsSearchTools:
             log_group_name: The log group to search
             query: CloudWatch Logs Insights query syntax
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with search results
@@ -72,8 +74,10 @@ class CloudWatchLogsSearchTools:
             log_group_names: List of log groups to search
             query: CloudWatch Logs Insights query syntax
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with search results
@@ -141,8 +145,10 @@ class CloudWatchLogsSearchTools:
             log_group_name: The log group to filter
             filter_pattern: The pattern to search for (CloudWatch Logs filter syntax)
             hours: Number of hours to look back
-            start_time: Start time in ISO8601 format
-            end_time: End time in ISO8601 format
+            start_time: Start time in ISO8601 format. Naive (offset-less) values
+                are interpreted as UTC; explicit offsets are honored.
+            end_time: End time in ISO8601 format. Naive (offset-less) values are
+                interpreted as UTC; explicit offsets are honored.
 
         Returns:
             JSON string with filtered events

--- a/src/cw_mcp_server/tools/utils.py
+++ b/src/cw_mcp_server/tools/utils.py
@@ -3,8 +3,24 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import dateutil.parser
+
+
+def _parse_iso_utc(value: str) -> datetime:
+    """Parse an ISO8601 string, treating naive (offset-less) input as UTC.
+
+    ``dateutil.parser.isoparse`` returns a tz-naive ``datetime`` when the input
+    has no ``Z`` suffix or explicit offset. Calling ``.timestamp()`` on a naive
+    datetime interprets it in the *host* local timezone, which would shift the
+    epoch by the server's UTC offset. We pin naive values to UTC so the result
+    is independent of where the server runs. Offset-aware values are returned
+    unchanged so explicit offsets are always honored.
+    """
+    parsed = dateutil.parser.isoparse(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def get_time_range(hours: int, start_time: str = None, end_time: str = None):
@@ -13,20 +29,24 @@ def get_time_range(hours: int, start_time: str = None, end_time: str = None):
 
     Args:
         hours: Number of hours to look back (used if start_time is not provided)
-        start_time: Optional ISO8601 start time
-        end_time: Optional ISO8601 end time
+        start_time: Optional ISO8601 start time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets are honored.
+        end_time: Optional ISO8601 end time. Naive (offset-less) values are
+            interpreted as UTC; explicit offsets are honored.
 
     Returns:
         Tuple of (start_timestamp, end_timestamp) in milliseconds since epoch
     """
     if start_time:
-        start_ts = int(dateutil.parser.isoparse(start_time).timestamp() * 1000)
+        start_ts = int(_parse_iso_utc(start_time).timestamp() * 1000)
     else:
-        start_ts = int((datetime.now() - timedelta(hours=hours)).timestamp() * 1000)
+        start_ts = int(
+            (datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp() * 1000
+        )
 
     if end_time:
-        end_ts = int(dateutil.parser.isoparse(end_time).timestamp() * 1000)
+        end_ts = int(_parse_iso_utc(end_time).timestamp() * 1000)
     else:
-        end_ts = int(datetime.now().timestamp() * 1000)
+        end_ts = int(datetime.now(timezone.utc).timestamp() * 1000)
 
     return start_ts, end_ts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,68 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cw_mcp_server.tools.utils.get_time_range.
+
+These tests pin a non-UTC host timezone (Asia/Tokyo, +09:00) to prove that a
+*naive* ISO8601 timestamp (no Z, no offset) is interpreted as UTC rather than
+as the server's local time. The relative (hours-based) path is also checked to
+remain anchored to UTC.
+"""
+
+import time
+
+import pytest
+
+from cw_mcp_server.tools.utils import get_time_range
+
+
+@pytest.fixture
+def tokyo_tz(monkeypatch):
+    """Run the test body with the host timezone set to Asia/Tokyo (+09:00)."""
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    time.tzset()
+    yield
+    # monkeypatch restores the TZ env var on teardown; re-apply it to the C lib.
+    time.tzset()
+
+
+def test_naive_iso_treated_as_utc_under_non_utc_tz(tokyo_tz):
+    """A naive ISO string must yield the same epoch as its UTC/offset equivalents.
+
+    Under TZ=Asia/Tokyo, the buggy implementation interpreted
+    "2025-01-01T00:00:00" as 00:00 *Tokyo* time, drifting the epoch 9h earlier
+    than the intended 00:00 UTC.
+    """
+    naive_start, _ = get_time_range(24, "2025-01-01T00:00:00", None)
+    zulu_start, _ = get_time_range(24, "2025-01-01T00:00:00Z", None)
+    offset_start, _ = get_time_range(24, "2025-01-01T09:00:00+09:00", None)
+
+    # All three describe the same instant (2025-01-01T00:00:00Z).
+    assert naive_start == zulu_start
+    assert naive_start == offset_start
+
+
+def test_explicit_offset_is_honored(tokyo_tz):
+    """An explicit offset must be respected, not overridden by the host TZ."""
+    # 2025-01-01T00:00:00+09:00 is 2024-12-31T15:00:00Z.
+    aware_start, _ = get_time_range(24, "2025-01-01T00:00:00+09:00", None)
+    utc_equivalent_start, _ = get_time_range(24, "2024-12-31T15:00:00Z", None)
+    assert aware_start == utc_equivalent_start
+
+
+def test_naive_end_time_treated_as_utc(tokyo_tz):
+    """The end_time path must apply the same UTC assumption for naive input."""
+    _, naive_end = get_time_range(24, None, "2025-01-01T00:00:00")
+    _, zulu_end = get_time_range(24, None, "2025-01-01T00:00:00Z")
+    assert naive_end == zulu_end
+
+
+def test_returns_millisecond_epochs():
+    """Return shape: a tuple of two ints in milliseconds since epoch."""
+    start_ts, end_ts = get_time_range(
+        24, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"
+    )
+    assert isinstance(start_ts, int)
+    assert isinstance(end_ts, int)
+    # 24h apart, expressed in milliseconds.
+    assert end_ts - start_ts == 24 * 60 * 60 * 1000

--- a/uv.lock
+++ b/uv.lock
@@ -258,6 +258,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -300,10 +309,12 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "mcp", extra = ["cli"] },
+    { name = "python-dateutil" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -311,10 +322,14 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.37.11" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "python-dateutil", specifier = ">=2.9" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.11.10" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "ruff", specifier = ">=0.11.10" },
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -366,6 +381,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -497,6 +530,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`get_time_range()` converts a user-supplied **naive** ISO8601 timestamp (no `Z`, no offset, e.g. `2025-01-01T00:00:00`) to the wrong epoch. The resulting CloudWatch query window is silently shifted by the server's local UTC offset — e.g. under `TZ=Asia/Tokyo` a "00:00" start time is sent 9 hours early. Identical inputs return different log windows depending on where the server runs.

## Root cause

`dateutil.parser.isoparse()` returns a tz-**naive** `datetime` for offset-less input. Calling `.timestamp()` on a naive datetime makes Python interpret it in the **host local timezone**, not UTC. The relative (hours-based) branch had the same latent issue via `datetime.now()`.

Secondary issue: `utils.py` does `import dateutil.parser` directly, but `python-dateutil` was **not a declared dependency** — `pyproject.toml` listed only `boto3` + `mcp[cli]`, with `python-dateutil` present only transitively through `botocore`.

## Fix

- After `isoparse(...)`, if `tzinfo is None`, set UTC via `.replace(tzinfo=timezone.utc)`; offset-aware values pass through unchanged (explicit offsets are honored).
- Relative path uses `datetime.now(timezone.utc)`.
- Declare `python-dateutil>=2.9` as a direct `[project]` dependency; `uv lock` regenerated.

## Testing

Bootstrapped `tests/` (the repo's first tests) with `pytest` in the dev group. Tests pin `TZ=Asia/Tokyo` and assert the naive string yields the same epoch as the `Z` and `+09:00` equivalents, that explicit offsets are honored, and the return shape. Pre-fix the naive cases drift `-9h`; post-fix 4 passed. `ruff check`/`format` and `pre-commit` clean.

## Docs

The six MCP tool docstrings, underlying tool-method docstrings, CLI `--start-time`/`--end-time` help, and a new "Time ranges & timezones" section in `docs/usage.md` now document that naive timestamps are UTC and explicit offsets are honored.

## Risk

Low. Behavior changes **only** for naive inputs on non-UTC hosts — and that prior behavior was a bug. Offset-aware inputs and UTC hosts are unaffected.

> Maintainer note: the load-bearing decision is interpreting **naive** timestamps as UTC (vs host-local). UTC makes results deterministic and host-independent — the natural expectation for a CloudWatch tool. The choice is isolated to the `_parse_iso_utc` helper if you'd prefer host-local or a config option. No issue to close (related #2 was mis-retracted).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
